### PR TITLE
fix authors having leading whitespace

### DIFF
--- a/orchard/vitals/facets/author_facet.py
+++ b/orchard/vitals/facets/author_facet.py
@@ -19,6 +19,6 @@ def author_facet(obj):
     # we just strip out the color tag and that's it
     authors, _ = parse_color_tagged_string(author_raw.strip())
 
-    author_tokens = [s for s in re.split(AUTHOR_REGEX, authors) if s]
+    author_tokens = [s.strip() for s in re.split(AUTHOR_REGEX, authors) if s]
 
     return author_tokens

--- a/orchard/vitals/test/__snapshots__/test_snapshots.ambr
+++ b/orchard/vitals/test/__snapshots__/test_snapshots.ambr
@@ -46,6 +46,61 @@
     'two_player': True,
   })
 # ---
+# name: test_snapshot[Green_wisteria_-_RGB.rdzip]
+  dict({
+    'artist': 'Green wisteria',
+    'artist_tokens': list([
+      'Green wisteria',
+    ]),
+    'authors': list([
+      'Delta',
+      'Xeno',
+    ]),
+    'description': '''
+      (CW: Body Horror)
+      A white lily bloomed, a black maw devoured.
+    ''',
+    'description_ct': list([
+      dict({
+        'color': 'default',
+        'len': 61,
+      }),
+    ]),
+    'difficulty': 2,
+    'has_classics': True,
+    'has_freetimes': True,
+    'has_freezeshots': False,
+    'has_holds': False,
+    'has_oneshots': True,
+    'has_skipshots': False,
+    'has_squareshots': False,
+    'has_window_dance': False,
+    'hue': 0.66,
+    'id': 'rgb-7krFijAGF4D',
+    'last_updated': datetime.datetime(2022, 9, 23, 9, 27, 28),
+    'max_bpm': 204,
+    'min_bpm': 100,
+    'rdlevel_sha1': '17a41d4c9b575d3202b8832a9d21c3b873d959e5',
+    'seizure_warning': True,
+    'sha1': '88f48cdbd6a63773fcf44a38f5ed1ece00f399be',
+    'single_player': True,
+    'song': 'RGB',
+    'song_ct': list([
+      dict({
+        'color': 'default',
+        'len': 3,
+      }),
+    ]),
+    'tags': list([
+      'compo19',
+      'competition 19',
+      'weird',
+      'red green blue',
+      'namine ritsu',
+    ]),
+    'two_player': False,
+  })
+# ---
 # name: test_snapshot[Hot_Freaks_-_Pull.rdzip]
   dict({
     'artist': 'Hot Freaks',
@@ -412,7 +467,7 @@
     ]),
     'authors': list([
       'auburnsummer',
-      ' Xeno',
+      'Xeno',
     ]),
     'description': 'A two-handed level. The eloquent blend between thirds and halves.',
     'description_ct': list([

--- a/orchard/vitals/test/fixtures/Green_wisteria_-_RGB.rdzip
+++ b/orchard/vitals/test/fixtures/Green_wisteria_-_RGB.rdzip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:928ed3cef8ccc89965f80125112efec3a0598258143cf1c3bdb763a9531a8a6d
+size 6251756


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/37142182/197338269-0870dcf5-533a-485c-8561-65d0634a78ad.png)

Fixes this bug where Xeno appears twice. one of the xenos is a ` Xeno` with leading whitespace. This is a regression.

Also add a new fixture test to avoid future regressions of this type. Actually, this was picked up by the Triplet Test fixture, but I didn't notice 😓 