### PR TITLE
fix: allow immediate key after a value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,5 @@ cython_debug/
 *.jsonl
 
 *.dev.yml
+
+tmp

--- a/orchard/parse/README.md
+++ b/orchard/parse/README.md
@@ -31,6 +31,12 @@ even though it has newlines"
 {"key": 2, "key2": 3 "key3": 4, "key4": [1, 2, 3] "key5": "hello world"}
 ```
 
+**Key pairs in objects can be implicitly continued**:
+
+```
+{"key": 2"key2": 3"key3": 4}
+```
+
 # Implementation
 
 This is a modified version of [naya](https://github.com/danielyule/naya) to add the relevant

--- a/orchard/parse/__main__.py
+++ b/orchard/parse/__main__.py
@@ -8,7 +8,7 @@ def with_first_file_or_stdin(func):
             # no arg
             func(sys.stdin)
         else:
-            with open(sys.argv[1], 'r') as f:
+            with open(sys.argv[1], 'r', encoding='utf-8-sig') as f:
                 func(f)
     return inner
 

--- a/orchard/parse/naya.py
+++ b/orchard/parse/naya.py
@@ -106,6 +106,11 @@ def tokenize(stream):
                 completed = True
                 now_token = (TOKEN_TYPE.NUMBER, int("".join(token)))
                 advance = False
+            elif char == "\"":
+                next_state = __TOKENIZER_STATE.STRING
+                completed = True
+                now_token = (TOKEN_TYPE.NUMBER, int("".join(token)))
+                advance = True
             else:
                 raise ValueError("A number must contain only digits.  Got '{}'".format(char))
         elif state == __TOKENIZER_STATE.INTEGER_0:
@@ -341,14 +346,17 @@ def parse_string(string):
 
 def parse(file):
     token_stream = tokenize(file)
-    val, token_type, token = __parse(token_stream, next(token_stream))
+    token_stream2 = list(token_stream)
+    print(token_stream2)
+    token_stream3 = iter(token_stream2)
+    val, token_type, token = __parse(token_stream3, next(token_stream3))
     if token is not None:
         if token == ',':
             pass
         else:
             raise ValueError("Improperly closed JSON object")
     try:
-        next(token_stream)
+        next(token_stream3)
     except StopIteration:
         return val
     raise ValueError("Additional string after end of JSON")

--- a/orchard/parse/naya.py
+++ b/orchard/parse/naya.py
@@ -125,6 +125,11 @@ def tokenize(stream):
                 completed = True
                 now_token = (TOKEN_TYPE.NUMBER, 0)
                 advance = False
+            elif char == "\"":
+                next_state = __TOKENIZER_STATE.STRING
+                completed = True
+                now_token = (TOKEN_TYPE.NUMBER, 0)
+                advance = True
             else:
                 raise ValueError("A 0 must be followed by a '.' or a 'e'.  Got '{0}'".format(char))
         elif state == __TOKENIZER_STATE.INTEGER_SIGN:
@@ -150,6 +155,11 @@ def tokenize(stream):
                 now_token = (TOKEN_TYPE.NUMBER, float("".join(token)))
                 next_state = __TOKENIZER_STATE.WHITESPACE
                 advance = False
+            elif char == "\"":
+                next_state = __TOKENIZER_STATE.STRING
+                completed = True
+                now_token = (TOKEN_TYPE.NUMBER, 0)
+                advance = True
             else:
                 raise ValueError("A number exponent must consist only of digits.  Got '{}'".format(char))
         elif state == __TOKENIZER_STATE.FLOATING_POINT:
@@ -163,6 +173,11 @@ def tokenize(stream):
                 now_token = (TOKEN_TYPE.NUMBER, float("".join(token)))
                 next_state = __TOKENIZER_STATE.WHITESPACE
                 advance = False
+            elif char == "\"":
+                next_state = __TOKENIZER_STATE.STRING
+                completed = True
+                now_token = (TOKEN_TYPE.NUMBER, 0)
+                advance = True
             else:
                 raise ValueError("A number must include only digits")
         elif state == __TOKENIZER_STATE.FLOATING_POINT_0:
@@ -346,17 +361,14 @@ def parse_string(string):
 
 def parse(file):
     token_stream = tokenize(file)
-    token_stream2 = list(token_stream)
-    print(token_stream2)
-    token_stream3 = iter(token_stream2)
-    val, token_type, token = __parse(token_stream3, next(token_stream3))
+    val, token_type, token = __parse(token_stream, next(token_stream))
     if token is not None:
         if token == ',':
             pass
         else:
             raise ValueError("Improperly closed JSON object")
     try:
-        next(token_stream3)
+        next(token_stream)
     except StopIteration:
         return val
     raise ValueError("Additional string after end of JSON")

--- a/orchard/parse/test/test_parse.py
+++ b/orchard/parse/test/test_parse.py
@@ -122,3 +122,13 @@ def test_space_seperated_after_array():
         "rooms": [0],
         "strength": "High"
     }
+
+
+def test_seperated_by_nothing_at_all():
+    s = r"""{ "bar": 3"foo": 4"foobar": 5}"""
+
+    assert parse(s) == {
+        "bar": 3,
+        "foo": 4,
+        "foobar": 5
+    }


### PR DESCRIPTION
This fixes an issue where we were not parsing some valid rdlevels correctly, see https://github.com/auburnsummer/rd-indexer/issues/16