### PR TITLE
Use Litestream in github workflows instead of file endpoint

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -24,7 +24,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: install litestream
-        run: wget https://github.com/benbjohnson/litestream/releases/download/v0.3.9/litestream-v0.3.9-linux-amd64.deb && dpkg -i litestream-v0.3.9-linux-amd64.deb
+        run: wget https://github.com/benbjohnson/litestream/releases/download/v0.3.9/litestream-v0.3.9-linux-amd64.deb && sudo dpkg -i litestream-v0.3.9-linux-amd64.deb
       
       - name: print litestream version
         run: litestream version

--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -40,18 +40,20 @@ jobs:
           LITESTREAM_PATH: status-main
           LITESTREAM_DB: ./status.db
 
-      # - name: upload to b2
-      # - name: configure b2
-      #   run: b2 authorize-account $B2_KEY_ID $B2_APPLICATION_KEY
-      #   env:
-      #     B2_APPLICATION_KEY: ${{ secrets.B2_APPLICATION_KEY }}
-      #     B2_KEY_ID: ${{ secrets.B2_KEY_ID }}
- 
-      # - name: print b2 account info
-      #   run: b2 get-account-info
-      # - name: Download the old DB
-      #   run: curl https://botprod.auburn.dev/status.db -o status.db
-      # - name: shasum of it
-      #   run: sha1sum status.db
-      # - name: upload to b2
-      #   run: b2 upload-file rdsqlite status.db backups/status.db        
+      - name: install b2
+        run: pipx install b2
+        
+      - name: configure b2
+        run: b2 authorize-account $B2_KEY_ID $B2_APPLICATION_KEY
+        env:
+          B2_APPLICATION_KEY: ${{ secrets.B2_APPLICATION_KEY }}
+          B2_KEY_ID: ${{ secrets.B2_KEY_ID }}
+
+      - name: print b2 account info
+        run: b2 get-account-info
+
+      - name: shasum of it
+        run: sha1sum status.db
+
+      - name: upload to b2
+        run: b2 upload-file rdsqlite status.db backups/status.db

--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -23,20 +23,22 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - name: install b2
-        run: pipx install b2
-        
-      - name: configure b2
-        run: b2 authorize-account $B2_KEY_ID $B2_APPLICATION_KEY
-        env:
-          B2_APPLICATION_KEY: ${{ secrets.B2_APPLICATION_KEY }}
-          B2_KEY_ID: ${{ secrets.B2_KEY_ID }}
+      - name: install litestream
+        run: wget https://github.com/benbjohnson/litestream/releases/download/v0.3.9/litestream-v0.3.9-linux-amd64.deb && dpkg -i litestream-v0.3.9-linux-amd64.deb
+      
+      - name: print litestream version
+        run: litestream version
+      # - name: configure b2
+      #   run: b2 authorize-account $B2_KEY_ID $B2_APPLICATION_KEY
+      #   env:
+      #     B2_APPLICATION_KEY: ${{ secrets.B2_APPLICATION_KEY }}
+      #     B2_KEY_ID: ${{ secrets.B2_KEY_ID }}
  
-      - name: print b2 account info
-        run: b2 get-account-info
-      - name: Download the old DB
-        run: curl https://botprod.auburn.dev/status.db -o status.db
-      - name: shasum of it
-        run: sha1sum status.db
-      - name: upload to b2
-        run: b2 upload-file rdsqlite status.db backups/status.db        
+      # - name: print b2 account info
+      #   run: b2 get-account-info
+      # - name: Download the old DB
+      #   run: curl https://botprod.auburn.dev/status.db -o status.db
+      # - name: shasum of it
+      #   run: sha1sum status.db
+      # - name: upload to b2
+      #   run: b2 upload-file rdsqlite status.db backups/status.db        

--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -28,6 +28,19 @@ jobs:
       
       - name: print litestream version
         run: litestream version
+
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: get the file from litestream
+        run: litestream restore -config orchard/bot/litestream.yml
+        env:
+          KEY_ID: ${{ secrets.B2_KEY_ID }}
+          B2_ACCESS_KEY: ${{ secrets.B2_APPLICATION_KEY }}
+          LITESTREAM_PATH: status-main
+          LITESTREAM_DB: ./status.db
+
+      # - name: upload to b2
       # - name: configure b2
       #   run: b2 authorize-account $B2_KEY_ID $B2_APPLICATION_KEY
       #   env:

--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: get the file from litestream
-        run: litestream restore -config orchard/bot/litestream.yml
+        run: litestream restore -config orchard/bot/litestream.yml ./status.db
         env:
           KEY_ID: ${{ secrets.B2_KEY_ID }}
           B2_ACCESS_KEY: ${{ secrets.B2_APPLICATION_KEY }}

--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: get the file from litestream
-        run: litestream restore -config orchard/bot/litestream.yml ./status.db
+        run: litestream restore -v -config orchard/bot/litestream.yml ./status.db
         env:
           KEY_ID: ${{ secrets.B2_KEY_ID }}
           B2_ACCESS_KEY: ${{ secrets.B2_APPLICATION_KEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,11 +87,14 @@ jobs:
     steps:
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v3.x
+
+      - name: install litestream
+        run: wget https://github.com/benbjohnson/litestream/releases/download/v0.3.9/litestream-v0.3.9-linux-amd64.deb && sudo dpkg -i litestream-v0.3.9-linux-amd64.deb
         
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: checkout
         uses: actions/checkout@v3
-        
+
       - name: Install poetry
         run: pipx install poetry
 
@@ -120,10 +123,14 @@ jobs:
       - name: download DB from previous job
         run: b2 download-file-by-name rdsqlite backups/orchard-${{ env.GITHUB_REF_SLUG }}.db orchard.db
         working-directory: ./orchard/package
-        
-      - name: download status DB from bot
-        run: curl https://botprod.auburn.dev/status.db -o status.db
-        working-directory: ./orchard/package
+
+      - name: get the file from litestream
+        run: litestream restore -v -config orchard/bot/litestream.yml ./orchard/package/status.db
+        env:
+          KEY_ID: ${{ secrets.B2_KEY_ID }}
+          B2_ACCESS_KEY: ${{ secrets.B2_APPLICATION_KEY }}
+          LITESTREAM_PATH: status-main
+          LITESTREAM_DB: ./orchard/package/status.db
 
       - name: print out hashes of the aforementioned dbs
         run: sha1sum *.db


### PR DESCRIPTION
Use the `litestream restore` in workflows to retrieve the `status.db` file, instead of the `/status.db` endpoint. 

Once this is merged we can remove the `/status.db` endpoint.