### PR TITLE
wrap `/plpasscode` response in backticks

### DIFF
--- a/orchard/bot/handlers/interactions/commands/passcode.py
+++ b/orchard/bot/handlers/interactions/commands/passcode.py
@@ -35,7 +35,7 @@ async def _passcode(body, _):
             # only the caller can see the actual passcode, the visible message is an emoji
             await i.edit(start_message().content("🙈"), "@original")
 
-            await i.post(start_message().content(passcode).ephemeral())
+            await i.post(start_message().content(f"`{passcode}`").ephemeral())
 
 
 passcode = SlashRoute(


### PR DESCRIPTION
This prevents it from rendering as italic if the passcode happens to contain markdown in it