### PR TITLE
`/plpasscode [check]` is ephemeral

### DIFF
--- a/orchard/bot/handlers/interactions/commands/passcode.py
+++ b/orchard/bot/handlers/interactions/commands/passcode.py
@@ -37,6 +37,9 @@ async def _passcode(body, _):
 
             await i.post(start_message().content(f"`{passcode}`").ephemeral())
 
+def _defer(body, request):
+    [private] = get_slash_args(["check"], body)
+    return RouteType.DEFER_EPHEMERAL if private else RouteType.DEFER_VISIBLE
 
 passcode = SlashRoute(
     name="plpasscode",
@@ -50,5 +53,5 @@ passcode = SlashRoute(
         )
     ],
     handler=_passcode,
-    defer=RouteType.DEFER_VISIBLE,
+    defer=_defer,
 )

--- a/orchard/bot/handlers/interactions/commands/passcode.py
+++ b/orchard/bot/handlers/interactions/commands/passcode.py
@@ -37,9 +37,11 @@ async def _passcode(body, _):
 
             await i.post(start_message().content(f"`{passcode}`").ephemeral())
 
+
 def _defer(body, request):
     [private] = get_slash_args(["check"], body)
     return RouteType.DEFER_EPHEMERAL if private else RouteType.DEFER_VISIBLE
+
 
 passcode = SlashRoute(
     name="plpasscode",


### PR DESCRIPTION
Make the `/plpasscode [check]` route completely ephemeral (no one else can see). This is because the original command can be viewed by clicking on the blue text of the command.

