### PR TITLE
Add the ability for the bot to react using the reactx command

### DIFF
--- a/orchard/bot/handlers/interactions/commands/reactx.py
+++ b/orchard/bot/handlers/interactions/commands/reactx.py
@@ -11,15 +11,23 @@ async def _reactx(body, _):
     async with Interactor(body["token"]) as i:
         channel_id = body["channel_id"]
         token = body["token"]
+        user_id = body["member"]["user"]["id"]
         messages = body["data"]["resolved"]["messages"]
+        number_reactions = ["1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣", "🔟"]
         for key, value in messages.items():
             message_id = value["id"]
+            for reaction in number_reactions:
+                if reaction not in [react["emoji"]["name"] for react in value["reactions"]]:
+                    continue
+                reaction_users = await i.get_reactions(channel_id, message_id, reaction)
+                if user_id in [reactor["id"] for reactor in reaction_users.json()]:
+                    await i.react(channel_id, message_id, reaction)
             await i.react(channel_id, message_id, "🚫")
         await i.edit(MessageBuilder().content("done."), "@original")
 
 
 reactx = SlashRoute(
-    name="reactx",
+    name="Ignore rdzip attachments",
     description="",
     handler=_reactx,
     default_permission=False,

--- a/orchard/bot/lib/comm/interactor.py
+++ b/orchard/bot/lib/comm/interactor.py
@@ -10,6 +10,8 @@ from orchard.utils.constants import DISCORD_API_URL
 from orchard.bot.lib.comm import pager
 from typing import Callable, List, Awaitable
 
+import urllib.parse
+
 base_url = f"{DISCORD_API_URL}/webhooks/{APPLICATION_ID}"
 
 logger = logging.getLogger(__name__)
@@ -103,6 +105,13 @@ class Interactor:
     async def react(self, channel_id, message_id, emoji):
         return await self.client.put(
             f"{DISCORD_API_URL}/channels/{channel_id}/messages/{message_id}/reactions/{emoji}/@me",
+            headers={"Authorization": f"Bot {BOT_TOKEN}"},
+        )
+    
+    @could_raise
+    async def get_reactions(self, channel_id, message_id, emoji):
+        return await self.client.get(
+            f"{DISCORD_API_URL}/channels/{channel_id}/messages/{message_id}/reactions/{urllib.parse.quote(emoji)}",
             headers={"Authorization": f"Bot {BOT_TOKEN}"},
         )
 


### PR DESCRIPTION
Pharmacists who want to ignore specific rdzips from a message should react with the number/s corresponding to the order of the attachment/s, then click the "Ignore rdzip attachments" command. The bot will then add its own number reaction to the message, and it will ignore the attachments when indexing. If no number reaction is seen, then the indexer will ignore all attachments in the message.