### PR TITLE
Improve qol for multiple attachment reactions

### DIFF
--- a/orchard/scan/sources/discord.py
+++ b/orchard/scan/sources/discord.py
@@ -157,14 +157,16 @@ class DiscordScraper(RDLevelScraper):
                     # check all attachments and corresponding number reactions. if no number reaction is found, then we ignore every attachment
                     ignore_all_attachments = True
                     attachment_numbers = []
+                    relative_position = 0
                     for i, attachment in enumerate(post["attachments"]):
                         if attachment["filename"].endswith(".rdzip"):
                             if remove_attachments and await self.check_reaction(
-                                post, number_reactions[i]
+                                post, number_reactions[relative_position], True
                             ):
                                 ignore_all_attachments = False
                                 continue
                             attachment_numbers.append(i)
+                            relative_position += 1
 
                     if (not remove_attachments) or (not ignore_all_attachments):
                         for i in attachment_numbers:


### PR DESCRIPTION
- The number reactions now only account for rdzip attachment positions (ignoring all other attachment positions), useful for messages with both image/video embeds and rdzips since embeds are always above other attachments and the actual order might be different
- Using the reactx command no longer reacts for numbers greater than the number of rdzips
- Using the reactx command now shows the rdzips that will be ignored (or all rdzips if no number reaction is found)